### PR TITLE
feat: implement GetVegaTime method

### DIFF
--- a/examples/market_data.py
+++ b/examples/market_data.py
@@ -55,19 +55,16 @@ PARSER.add_argument(
     default=["BTC"],
     help="Specify substrings to match against market codes.",
 )
-DEFAULT_END_DATE = datetime.datetime.now()
-DEFAULT_START_DATE = DEFAULT_END_DATE - datetime.timedelta(hours=2)
+
 PARSER.add_argument(
     "--start_datetime",
     type=datetime.datetime.fromisoformat,
     help="Specify datetime to retrieve data from (format: YYYY-MM-DD:HH:mm:ss).",
-    default=DEFAULT_START_DATE,
 )
 PARSER.add_argument(
     "--end_datetime",
     type=datetime.datetime.fromisoformat,
     help="Specify datetime to retrieve data to (format: YYYY-MM-DD:HH:mm:ss).",
-    default=DEFAULT_END_DATE,
 )
 
 
@@ -139,13 +136,24 @@ if __name__ == "__main__":
         network, pathlib.Path(args.config) if args.config else None
     )
 
+    if args.start_datetime is None:
+        start_timestamp = int(
+            service.api.data.get_vega_time() - 1 * 60 * 60 * 1e9
+        )
+    else:
+        start_timestamp = datetime_to_timestamp(args.start_datetime, nano=True)
+    if args.end_datetime is None:
+        end_timestamp = int(service.api.data.get_vega_time())
+    else:
+        end_timestamp = datetime_to_timestamp(args.end_datetime, nano=True)
+
     # Get the market, asset, and market data for the specified market and times
     market = service.utils.market.find_market(args.market)
     asset = service.utils.market.find_settlement_asset(args.market)
     market_data_history = service.api.data.get_market_data_history_by_id(
         market_id=market.id,
-        start_timestamp=datetime_to_timestamp(args.start_datetime, nano=True),
-        end_timestamp=datetime_to_timestamp(args.end_datetime, nano=True),
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
         max_pages=args.pages,
     )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -72,3 +72,13 @@ def governance_data(
     tds: TradingDataService,
 ) -> List[protos.vega.governance.GovernanceData]:
     return tds.list_governance_data(max_pages=1)
+
+
+@fixture(scope="session")
+def start_timestamp(tds: TradingDataService) -> int:
+    return int(tds.get_vega_time() - (1 * 60 * 60 * 1e9))
+
+
+@fixture(scope="session")
+def end_timestamp(tds: TradingDataService) -> int:
+    return int(tds.get_vega_time() - (2 * 60 * 60 * 1e9))

--- a/tests/service/service_trading_data/test_get_market_data_history_by_id.py
+++ b/tests/service/service_trading_data/test_get_market_data_history_by_id.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vegapy.service.service_trading_data import TradingDataService
-from tests.fixtures import tds, markets
+from tests.fixtures import tds, markets, start_timestamp, end_timestamp
 
 import vegapy.protobuf.protos as protos
 import datetime
@@ -11,9 +11,7 @@ import datetime
 def test_get_market_data_history_by_id_market_id(
     tds: TradingDataService, markets
 ):
-    market_id = (
-        "4e9081e20e9e81f3e747d42cb0c9b8826454df01899e6027a22e771e19cc79fc"
-    )
+    market_id = markets[0]
     for market_data in tds.get_market_data_history_by_id(
         market_id=market_id, max_pages=1
     ):
@@ -22,15 +20,9 @@ def test_get_market_data_history_by_id_market_id(
 
 @pytest.mark.trading_data_service
 def test_get_market_data_history_by_id_start_timestamp(
-    tds: TradingDataService, markets
+    tds: TradingDataService, markets, start_timestamp
 ):
-    market_id = (
-        "4e9081e20e9e81f3e747d42cb0c9b8826454df01899e6027a22e771e19cc79fc"
-    )
-    start_timestamp = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
+    market_id = markets[0]
     for market_data in tds.get_market_data_history_by_id(
         market_id=market_id, start_timestamp=start_timestamp, max_pages=1
     ):
@@ -39,15 +31,9 @@ def test_get_market_data_history_by_id_start_timestamp(
 
 @pytest.mark.trading_data_service
 def test_get_market_data_history_by_id_end_timestamp(
-    tds: TradingDataService, markets
+    tds: TradingDataService, markets, end_timestamp
 ):
-    market_id = (
-        "4e9081e20e9e81f3e747d42cb0c9b8826454df01899e6027a22e771e19cc79fc"
-    )
-    end_timestamp = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
+    market_id = markets[0]
     for market_data in tds.get_market_data_history_by_id(
         market_id=market_id, end_timestamp=end_timestamp, max_pages=1
     ):

--- a/tests/service/service_trading_data/test_get_vega_time.py
+++ b/tests/service/service_trading_data/test_get_vega_time.py
@@ -1,0 +1,13 @@
+import pytest
+
+from vegapy.service.service_trading_data import TradingDataService
+from tests.fixtures import tds
+
+import vegapy.protobuf.protos as protos
+
+
+@pytest.mark.trading_data_service
+def test_get_vega_time(tds: TradingDataService):
+    timestamp = tds.get_vega_time()
+    assert isinstance(timestamp, int)
+    assert timestamp > 0

--- a/tests/service/service_trading_data/test_list_funding_period_data_points.py
+++ b/tests/service/service_trading_data/test_list_funding_period_data_points.py
@@ -1,7 +1,13 @@
 import pytest
 
 from vegapy.service.service_trading_data import TradingDataService
-from tests.fixtures import logger, tds, perpetual_markets
+from tests.fixtures import (
+    logger,
+    tds,
+    perpetual_markets,
+    start_timestamp,
+    end_timestamp,
+)
 
 import vegapy.protobuf.protos as protos
 import datetime
@@ -22,36 +28,28 @@ def test_list_funding_period_data_points_market_id(
 
 @pytest.mark.trading_data_service
 def test_list_funding_period_data_points_start_timestamp(
-    tds: TradingDataService, perpetual_markets
+    tds: TradingDataService, perpetual_markets, start_timestamp
 ):
     market_id_filter = perpetual_markets[0]
-    start_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
     for funding_period_data_point in tds.list_funding_period_data_points(
         market_id=market_id_filter,
-        start_timestamp=start_timestamp_filter,
+        start_timestamp=start_timestamp,
         max_pages=1,
     ):
-        assert funding_period_data_point.timestamp > start_timestamp_filter
+        assert funding_period_data_point.timestamp > start_timestamp
 
 
 @pytest.mark.trading_data_service
 def test_list_funding_period_data_points_end_timestamp(
-    tds: TradingDataService, perpetual_markets
+    tds: TradingDataService, perpetual_markets, end_timestamp
 ):
     market_id_filter = perpetual_markets[0]
-    end_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
     for funding_period_data_point in tds.list_funding_period_data_points(
         market_id=market_id_filter,
-        end_timestamp=end_timestamp_filter,
+        end_timestamp=end_timestamp,
         max_pages=1,
     ):
-        assert funding_period_data_point.timestamp < end_timestamp_filter
+        assert funding_period_data_point.timestamp < end_timestamp
 
 
 def test_list_funding_period_data_points_source_filter(

--- a/tests/service/service_trading_data/test_list_ledger_entries.py
+++ b/tests/service/service_trading_data/test_list_ledger_entries.py
@@ -1,7 +1,14 @@
 import pytest
 
 from vegapy.service.service_trading_data import TradingDataService
-from tests.fixtures import tds, markets, parties, assets
+from tests.fixtures import (
+    tds,
+    markets,
+    parties,
+    assets,
+    start_timestamp,
+    end_timestamp,
+)
 
 import vegapy.protobuf.protos as protos
 
@@ -47,33 +54,25 @@ def test_list_ledger_entries_close_on_accounts_filter(
 
 @pytest.mark.trading_data_service
 def test_list_ledger_entries_date_range_start_timestamp(
-    tds: TradingDataService, parties
+    tds: TradingDataService, parties, start_timestamp
 ):
     from_party_ids_filter = [parties[0]]
-    date_range_start_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
     for ledger_entry in tds.list_ledger_entries(
         from_party_ids=from_party_ids_filter,
-        date_range_start_timestamp=date_range_start_timestamp_filter,
+        date_range_start_timestamp=start_timestamp,
         max_pages=1,
     ):
-        assert ledger_entry.timestamp > date_range_start_timestamp_filter
+        assert ledger_entry.timestamp > start_timestamp
 
 
 @pytest.mark.trading_data_service
 def test_list_ledger_entries_date_range_end_timestamp(
-    tds: TradingDataService, parties
+    tds: TradingDataService, parties, end_timestamp
 ):
     from_party_ids_filter = [parties[0]]
-    date_range_end_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
     for ledger_entry in tds.list_ledger_entries(
         from_party_ids=from_party_ids_filter,
-        date_range_end_timestamp=date_range_end_timestamp_filter,
+        date_range_end_timestamp=end_timestamp,
         max_pages=1,
     ):
-        assert ledger_entry.timestamp < date_range_end_timestamp_filter
+        assert ledger_entry.timestamp < end_timestamp

--- a/tests/service/service_trading_data/test_list_orders.py
+++ b/tests/service/service_trading_data/test_list_orders.py
@@ -1,7 +1,16 @@
 import pytest
 
 from vegapy.service.service_trading_data import TradingDataService
-from tests.fixtures import logger, tds, markets, assets, parties, orders
+from tests.fixtures import (
+    logger,
+    tds,
+    markets,
+    assets,
+    parties,
+    orders,
+    start_timestamp,
+    end_timestamp,
+)
 
 import vegapy.protobuf.protos as protos
 import datetime
@@ -64,27 +73,19 @@ def test_list_orders_reference(tds: TradingDataService, orders):
 
 
 @pytest.mark.trading_data_service
-def test_list_orders_start_timestamp(tds: TradingDataService):
-    start_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
+def test_list_orders_start_timestamp(tds: TradingDataService, start_timestamp):
     for order in tds.list_orders(
-        start_timestamp=start_timestamp_filter, live_only=True, max_pages=1
+        start_timestamp=start_timestamp, live_only=True, max_pages=1
     ):
-        assert max(order.created_at, order.updated_at) > start_timestamp_filter
+        assert max(order.created_at, order.updated_at) > start_timestamp
 
 
 @pytest.mark.trading_data_service
-def test_list_orders_end_timestamp(tds: TradingDataService):
-    end_timestamp_filter = int(
-        (datetime.datetime.now() - datetime.timedelta(days=1)).timestamp()
-        * 1e9
-    )
+def test_list_orders_end_timestamp(tds: TradingDataService, end_timestamp):
     for order in tds.list_orders(
-        end_timestamp=end_timestamp_filter, live_only=True, max_pages=1
+        end_timestamp=end_timestamp, live_only=True, max_pages=1
     ):
-        assert max(order.created_at, order.updated_at) < end_timestamp_filter
+        assert max(order.created_at, order.updated_at) < end_timestamp
 
 
 @pytest.mark.trading_data_service

--- a/vegapy/service/service_trading_data.py
+++ b/vegapy/service/service_trading_data.py
@@ -745,9 +745,10 @@ class TradingDataService:
     #     # TODO: Implement method
     #     pass
 
-    # def get_vega_time(self, max_pages: Optional[int] = None) -> Any:
-    #     # TODO: Implement method
-    #     pass
+    def get_vega_time(self) -> int:
+        return self.__stub.GetVegaTime(
+            trading_data.GetVegaTimeRequest()
+        ).timestamp
 
     # def get_protocol_upgrade_status(
     #     self, max_pages: Optional[int] = None


### PR DESCRIPTION
Adds a `get_vega_time` method to the `TradingDataService` and migrates existing tests which require time filtering to use consistent fixtures.