### PR TITLE
fix: remove logging from init

### DIFF
--- a/vegapy/__init__.py
+++ b/vegapy/__init__.py
@@ -1,6 +1,0 @@
-import yaml
-import logging.config
-
-with open("logging.yaml", "r") as file:
-    yaml_dict = yaml.safe_load(file)
-logging.config.dictConfig(yaml_dict)


### PR DESCRIPTION
Removes the default logger initiation from the init to streamline importing package as a third party dependency.