### PR TITLE
feat: add script for running analysis plots against networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .vscode
 extern/*
 .DS_Store
+plots/*

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,0 +1,136 @@
+import logging
+import datetime
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+import vegapy.visualisations as vis
+import vegapy.protobuf.protos as protos
+from vegapy.service.service import Service
+from vegapy.service.networks.constants import Network
+from scripts.parser import PARSER
+
+if __name__ == "__main__":
+
+    # Enrich parser with script specific options
+    plotting = PARSER.add_argument_group("Plotting options")
+    plotting.add_argument(
+        "--monitoring",
+        action="store_true",
+        default=False,
+        help="Specify whether to create the price monitoring analysis plot.",
+    )
+    plotting.add_argument(
+        "--liquidations",
+        action="store_true",
+        default=False,
+        help="Specify whether to create the liquidations analysis plot.",
+    )
+    plotting.add_argument(
+        "--funding",
+        action="store_true",
+        default=False,
+        help="Specify whether to create the funding analysis plot.",
+    )
+    plotting.add_argument(
+        "--tight",
+        action="store_true",
+        default=False,
+        help="Specify whether to plot all bounds or just the tightest bounds.",
+    )
+    args = PARSER.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    # Instantiate service for specified network
+    if args.network == "mainnet":
+        network = Network.NETWORK_MAINNET
+    if args.network == "stagnet":
+        network = Network.NETWORK_STAGNET
+    if args.network == "testnet":
+        network = Network.NETWORK_TESTNET
+    if args.network == "local":
+        network = Network.NETWORK_LOCAL
+    service = Service(
+        network=network,
+        network_config=(
+            Path(
+                f"{args.config}/vegahome/config/wallet-service/networks/local.toml"
+            )
+            if args.config is not None
+            else None
+        ),
+    )
+
+    # Request required data from network
+    network_timestamp = service.api.data.get_vega_time()
+    end_timestamp = (
+        network_timestamp
+        if args.end_time is None
+        else int(args.end_time.timestamp() * 1e9)
+    )
+    start_timestamp = (
+        network_timestamp - int(1 * 60 * 60 * 1e9)
+        if args.start_time is None
+        else int(args.start_time.timestamp() * 1e9)
+    )
+    market = service.utils.market.find_market([args.market])
+    asset = service.utils.market.find_settlement_asset([args.market])
+    market_data_history = service.api.data.get_market_data_history_by_id(
+        market_id=market.id,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        max_pages=args.pages,
+    )
+    if args.liquidations:
+        trades = service.api.data.list_trades(
+            market_ids=[market.id],
+            date_range_start_timestamp=start_timestamp,
+            date_range_end_timestamp=end_timestamp,
+        )
+        aggregated_balance_history = service.api.data.list_balance_changes(
+            party_ids=["network"],
+            market_ids=[market.id],
+            account_types=[
+                protos.vega.vega.AccountType.ACCOUNT_TYPE_INSURANCE
+            ],
+            date_range_start_timestamp=start_timestamp,
+            date_range_end_timestamp=end_timestamp,
+        )
+    if args.funding:
+        funding_periods = service.api.data.list_funding_periods(
+            market_id=market.id,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        )
+        funding_period_data_points = (
+            service.api.data.list_funding_period_data_points(
+                market_id=market.id,
+                start_timestamp=start_timestamp,
+                end_timestamp=end_timestamp,
+            )
+        )
+
+    # Build figures and optionally save or show
+    fig_m = vis.plot.price_monitoring_analysis(
+        market, market_data_history, tightest_bounds=args.tight
+    )
+    fig_l = vis.plot.liquidation_analysis(
+        asset,
+        market,
+        trades,
+        market_data_history,
+        aggregated_balance_history,
+    )
+    fig_f = vis.plot.funding_analysis(
+        asset,
+        market,
+        market_data_history,
+        funding_periods,
+        funding_period_data_points,
+    )
+    if args.save:
+        fig_f.savefig(f"plots/{datetime.datetime.now()}-funding.png")
+        fig_m.savefig(f"plots/{datetime.datetime.now()}-monitoring.png")
+        fig_l.savefig(f"plots/{datetime.datetime.now()}-liquidations.png")
+    if args.show:
+        plt.show()

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -1,0 +1,62 @@
+import datetime
+
+from argparse import ArgumentParser
+
+PARSER = ArgumentParser()
+
+general_options = PARSER.add_argument_group("General options")
+general_options.add_argument(
+    "-n",
+    "--network",
+    required=True,
+    type=str,
+    help="Specify network to request data from.",
+)
+general_options.add_argument(
+    "-m",
+    "--market",
+    default=True,
+    type=str,
+    help="Specify market to request data for.",
+)
+general_options.add_argument(
+    "-c",
+    "--config",
+    required=False,
+    type=str,
+    help="Specify path to network config file (only required when targetting a local network).",
+)
+general_options.add_argument(
+    "-p",
+    "--pages",
+    required=False,
+    default=None,
+    type=int,
+    help="Specify maximum number of pages service requests can return.",
+)
+general_options.add_argument(
+    "--start-time",
+    type=datetime.datetime.fromisoformat,
+    help="Specify datetime to retrieve data from (format: YYYY-MM-DD:HH:mm:ss).",
+)
+general_options.add_argument(
+    "--end-time",
+    type=datetime.datetime.fromisoformat,
+    help="Specify datetime to retrieve data to (format: YYYY-MM-DD:HH:mm:ss).",
+)
+
+output_options = PARSER.add_argument_group("Output options")
+output_options.add_argument(
+    "--debug", action="store_true", help="Enables debug mode."
+)
+output_options.add_argument(
+    "--show", action="store_true", help="Shows plot at end of script."
+)
+output_options.add_argument(
+    "--save", action="store_true", help="Saves plot at end of script."
+)
+
+
+if __name__ == "__main__":
+    args = PARSER.parse_args()
+    print(args)

--- a/vegapy/visualisations/plot.py
+++ b/vegapy/visualisations/plot.py
@@ -33,8 +33,9 @@ def price_monitoring_analysis(
     overlay_auction_ends(ax0r, market_data_history)
 
     ax0l.set_xlim(
-        timestamp_to_datetime(market.market_timestamps.pending, nano=True),
-        timestamp_to_datetime(market_data_history[0].timestamp, nano=True),
+        right=timestamp_to_datetime(
+            market_data_history[0].timestamp, nano=True
+        ),
     )
 
     ax0l.set_title(
@@ -95,8 +96,9 @@ def liquidation_analysis(
     overlay_balance(ax3l, aggregated_balance_history, asset.details.decimals)
     ax3l.set_ylabel("insurance pool")
     ax3l.set_xlim(
-        timestamp_to_datetime(market.market_timestamps.pending, nano=True),
-        timestamp_to_datetime(market_data_history[0].timestamp, nano=True),
+        right=timestamp_to_datetime(
+            market_data_history[0].timestamp, nano=True
+        ),
     )
 
     leg = ax0l.legend(loc="upper left", framealpha=1)
@@ -188,8 +190,9 @@ def funding_analysis(
     ax3r.set_yticks([])
     ax3l.set_xlabel(f"datetime")
     ax3l.set_xlim(
-        timestamp_to_datetime(market.market_timestamps.pending, nano=True),
-        timestamp_to_datetime(market_data_history[0].timestamp, nano=True),
+        right=timestamp_to_datetime(
+            market_data_history[0].timestamp, nano=True
+        ),
     )
     ax3l.axhline(0, alpha=0.5, color="k", linewidth=1)
 


### PR DESCRIPTION
Adds a script for creating the main analysis plots with data from any network.

#### Usage:
```bash
python -m scripts.main -h
```
#### Example:
```bash
python -m scripts.main -n mainnet -m BTC --monitoring --show --save
```

